### PR TITLE
Centering number for Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@ document.getElementById("demo2").innerHTML = hexmin;
 		.append("text")
 		.append("tspan")
 		.attr("text-anchor", "middle")
-		.attr("alignment-baseline","central")
+		.attr("dominant-baseline","middle")
 		.text(function(hex) {return hex.Divs;});
 
 


### PR DESCRIPTION
Swapped alignment-baseline for dominant-baseline as it's compatible with Firefox and Chrome. alignment-baseline just worked in Chrome. Numbers aren't centred in IE11, don't know why yet. 